### PR TITLE
fix workflow to check gdrive access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       GDRIVE_FOLDER: ${{ vars.GDRIVE_FOLDER }}
     steps:
     - uses: actions/checkout@v3
-    - run: "pip install -r gdrive_requirements.txt"
+    - run: "pip install -r requirements.txt"
     - run: "python test_pull_from_gdrive.py"
     - name: Archive pulled files
       uses: actions/upload-artifact@v2

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from model.election import Elections
 from model.filing import Filings
 from model.transaction import Transactions
 
-from gdrive_datastore.gdrive import test_data_pull
+from gdrive_datastore.gdrive import pull_data
 
 def get_last_status(status_list):
     """
@@ -30,7 +30,7 @@ def main():
     data_dir_path = '.local/downloads'
 
     # pull data from gdrive and put it in .local/downloads
-    test_data_pull(default_folder='OpenDisclosure')
+    pull_data(subfolder='main', default_folder='OpenDisclosure')
 
     #engine = create_engine('postgresql+psycopg2://localhost/disclosure-backend-v2', echo=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas~=2.0.3
 SQLAlchemy~=2.0.20
 psycopg2~=2.9.7
-gdrive-datastore==0.0.1.3
+gdrive-datastore==0.0.1.5

--- a/test_pull_from_gdrive.py
+++ b/test_pull_from_gdrive.py
@@ -1,4 +1,4 @@
 import os
 from gdrive_datastore.gdrive import test_data_pull
 
-test_data_pull(default_folder='OpenDisclosure')
+test_data_pull(default_folder='OpenDisclosure', default_subfolder='main')

--- a/test_pull_from_gdrive.py
+++ b/test_pull_from_gdrive.py
@@ -1,4 +1,4 @@
 import os
-from gdrive_datastore.gdrive import test_data_pull
+from gdrive_datastore.gdrive import pull_data
 
-test_data_pull(default_folder='OpenDisclosure', default_subfolder='main')
+pull_data(subfolder='main', default_folder='OpenDisclosure')


### PR DESCRIPTION
install requirements.txt instead of gdrive_requirements.txt

Before approving this, the workflow should work.  It currently doesn't work because the `SERVICE_ACCOUNT_KEY_JSON` secret hasn't been set with the key for the read-only service account.  Also, `GDRIVE_FOLDER` variable has to be set to `OpenDisclosure`.